### PR TITLE
Error handling fix.

### DIFF
--- a/src/tokenVerifier.js
+++ b/src/tokenVerifier.js
@@ -82,44 +82,49 @@ class TokenVerifier {
     )
     // Additional validation
     if (options.authorizedParty && payload.azp !== options.authorizedParty) {
-      throw new JWTClaimValidationFailed(
+      throw new errors.JWTClaimValidationFailed(
         "unexpected 'azp' claim value",
         'azp',
-        'check_failed'
+        'check_failed',
+        payload
       )
     }
     if (options.nonce && payload.nonce !== options.nonce) {
-      throw new JWTClaimValidationFailed(
+      throw new errors.JWTClaimValidationFailed(
         "unexpected 'nonce' claim value",
         'nonce',
-        'check_failed'
+        'check_failed',
+        payload
       )
     }
     if (options.type && payload.typ !== options.type) {
-      throw new JWTClaimValidationFailed(
+      throw new errors.JWTClaimValidationFailed(
         "unexpected 'typ' claim value",
         'typ',
-        'check_failed'
+        'check_failed',
+        payload
       )
     }
     if (
       options.authenticationContext &&
       payload.acr !== options.authenticationContext
     ) {
-      throw new JWTClaimValidationFailed(
+      throw new errors.JWTClaimValidationFailed(
         "unexpected 'acr' claim value",
         'acr',
-        'check_failed'
+        'check_failed',
+        payload
       )
     }
     if (
       options.sessionState &&
       payload.session_state !== options.sessionState
     ) {
-      throw new JWTClaimValidationFailed(
+      throw new errors.JWTClaimValidationFailed(
         "unexpected 'session_state' claim value",
         'session_state',
-        'check_failed'
+        'check_failed',
+        payload
       )
     }
     if (options.scope) {
@@ -132,15 +137,16 @@ class TokenVerifier {
         }
       }
       if (missingScopes.length > 0) {
-        throw new JWTClaimValidationFailed(
+        throw new errors.JWTClaimValidationFailed(
           `missing values (${missingScopes.join(', ')}) in the 'scope' claim`,
           'scope',
-          'check_failed'
+          'check_failed',
+          payload
         )
       }
     }
     if (options.keyID && protectedHeader.kid !== options.keyID) {
-      throw new JWTInvalid(
+      throw new errors.JWTInvalid(
         `expected token to be signed with ${options.keyID} but it was signed with ${protectedHeader.kid}`
       )
     }
@@ -156,13 +162,13 @@ class TokenVerifier {
    */
   decode(token) {
     if (typeof token !== 'string') {
-      throw new JWTInvalid(
+      throw new errors.JWTInvalid(
         'A JWT is a string of 3 period separated base64 values'
       )
     }
     const { 0: encodedHeader, 1: encodedClaims, length } = token.split('.')
     if (length !== 3) {
-      throw new JWTInvalid(
+      throw new errors.JWTInvalid(
         'A JWT is a string of 3 period separated base64 values'
       )
     }

--- a/src/tokenVerifier.js
+++ b/src/tokenVerifier.js
@@ -84,25 +84,25 @@ class TokenVerifier {
     if (options.authorizedParty && payload.azp !== options.authorizedParty) {
       throw new errors.JWTClaimValidationFailed(
         "unexpected 'azp' claim value",
+        payload,
         'azp',
         'check_failed',
-        payload
       )
     }
     if (options.nonce && payload.nonce !== options.nonce) {
       throw new errors.JWTClaimValidationFailed(
         "unexpected 'nonce' claim value",
+        payload,
         'nonce',
         'check_failed',
-        payload
       )
     }
     if (options.type && payload.typ !== options.type) {
       throw new errors.JWTClaimValidationFailed(
         "unexpected 'typ' claim value",
+        payload,
         'typ',
         'check_failed',
-        payload
       )
     }
     if (
@@ -111,9 +111,9 @@ class TokenVerifier {
     ) {
       throw new errors.JWTClaimValidationFailed(
         "unexpected 'acr' claim value",
+        payload,
         'acr',
         'check_failed',
-        payload
       )
     }
     if (
@@ -122,9 +122,9 @@ class TokenVerifier {
     ) {
       throw new errors.JWTClaimValidationFailed(
         "unexpected 'session_state' claim value",
+        payload,
         'session_state',
         'check_failed',
-        payload
       )
     }
     if (options.scope) {
@@ -139,9 +139,9 @@ class TokenVerifier {
       if (missingScopes.length > 0) {
         throw new errors.JWTClaimValidationFailed(
           `missing values (${missingScopes.join(', ')}) in the 'scope' claim`,
+          payload,
           'scope',
           'check_failed',
-          payload
         )
       }
     }

--- a/src/tokenVerifier.js
+++ b/src/tokenVerifier.js
@@ -86,7 +86,7 @@ class TokenVerifier {
         "unexpected 'azp' claim value",
         payload,
         'azp',
-        'check_failed',
+        'check_failed'
       )
     }
     if (options.nonce && payload.nonce !== options.nonce) {
@@ -94,7 +94,7 @@ class TokenVerifier {
         "unexpected 'nonce' claim value",
         payload,
         'nonce',
-        'check_failed',
+        'check_failed'
       )
     }
     if (options.type && payload.typ !== options.type) {
@@ -102,7 +102,7 @@ class TokenVerifier {
         "unexpected 'typ' claim value",
         payload,
         'typ',
-        'check_failed',
+        'check_failed'
       )
     }
     if (
@@ -113,7 +113,7 @@ class TokenVerifier {
         "unexpected 'acr' claim value",
         payload,
         'acr',
-        'check_failed',
+        'check_failed'
       )
     }
     if (
@@ -124,7 +124,7 @@ class TokenVerifier {
         "unexpected 'session_state' claim value",
         payload,
         'session_state',
-        'check_failed',
+        'check_failed'
       )
     }
     if (options.scope) {
@@ -141,7 +141,7 @@ class TokenVerifier {
           `missing values (${missingScopes.join(', ')}) in the 'scope' claim`,
           payload,
           'scope',
-          'check_failed',
+          'check_failed'
         )
       }
     }


### PR DESCRIPTION
JWTClaimValidationFailed, JWTInvalid error wrappers comes from jose library so we need to invoke it with 'errors.' else it throw undefined error.

This change fixes that undefined error.